### PR TITLE
Fix code scanning alert

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@<commit-SHA> # master
+        uses: openjournals/openjournals-draft-action@a994a876f36e25076174d9ed133e01b1f1b9fcf3 # master
         with:
           journal: joss
           paper-path: paper/paper.md

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -25,7 +25,7 @@ jobs:
           name: paper
           path: paper/paper.pdf
       - name: Commit PDF to repository
-        uses: EndBug/add-and-commit@<commit-SHA> # v9
+        uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b # v9
         with:
           message: '(auto) Paper PDF Draft'
           add: 'paper/paper.pdf'

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
+        uses: openjournals/openjournals-draft-action@<commit-SHA> # master
         with:
           journal: joss
           paper-path: paper/paper.md
@@ -25,7 +25,7 @@ jobs:
           name: paper
           path: paper/paper.pdf
       - name: Commit PDF to repository
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@<commit-SHA> # v9
         with:
           message: '(auto) Paper PDF Draft'
           add: 'paper/paper.pdf'

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -39,7 +39,7 @@ jobs:
         pytest --cov=gca_analyzer --cov-branch --cov-report=xml:coverage.xml tests/
           
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@<commit-SHA> # v5
+      uses: codecov/codecov-action@968872560f81e7bdde9272853e65f2507c0eca7c # v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: etShaw-zh/gca_analyzer

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -39,7 +39,7 @@ jobs:
         pytest --cov=gca_analyzer --cov-branch --cov-report=xml:coverage.xml tests/
           
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@<commit-SHA> # v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: etShaw-zh/gca_analyzer


### PR DESCRIPTION

- Replaced codecov/codecov-action@v5 with its corresponding commit SHA: <commit-SHA>.
- Replaced openjournals/openjournals-draft-action@master with the specific commit SHA: <commit-SHA>.
- Replaced EndBug/add-and-commit@v9 with the specific commit SHA: <commit-SHA>.

Close #23 